### PR TITLE
fix mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
 Then just run 
 
 ```shell
-rails generate vue:install
+rails generate vueport:install
 ```
 
 to bootstrap everything you need to get started (this will install WebpackRails and also everything Vueport needs on top).


### PR DESCRIPTION
Hi, I think there is a little mistake in the Installation part of the document,
it should be 
```shell
rails generate vueport:install
 ```
instead of
 ```shell
rails generate vue:install
 ```

 Forgive my poor English :)