### PR TITLE
Fix typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ E.g.:
         <%= yield %>
     <% end %>
 
-    <%= stylesheet_link_tag *webpack_asset_paths('application', extension:  'js') %>
+    <%= javascript_include_tag *webpack_asset_paths("application", extension: 'js') %>
 </body>
 ```
 


### PR DESCRIPTION
The README uses `stylesheet_link_tag` for the inclusion of the javascripts.